### PR TITLE
:sparkles: feat: 콘솔 키값 설정 & .net 7.0으로 변경

### DIFF
--- a/ConsoleCalculator/ConsoleCalculator/ConsoleCalculator.csproj
+++ b/ConsoleCalculator/ConsoleCalculator/ConsoleCalculator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/ConsoleCalculator/ConsoleCalculator/Program.cs
+++ b/ConsoleCalculator/ConsoleCalculator/Program.cs
@@ -12,13 +12,18 @@ namespace ConsoleCalculator
             string secondStringNumber = string.Empty;
             string operatorSymbol = string.Empty;
             double result = 0;
+            int currentIndex = 0;
 
             CalculateManager calculateManager = new CalculateManager();
             UIManager uiManager = new UIManager();
 
+            Console.ForegroundColor = ConsoleColor.Blue;
             Console.WriteLine("[Calculater]");
-            Console.Write("첫번째 숫자 입력 :");            
+            Console.ForegroundColor = ConsoleColor.Yellow;
 
+            SetCurrentIndexKey(currentIndex);
+
+            Console.Write("@첫번째 숫자 입력 :");
             firstStringNumber = Console.ReadLine();
             if (!CalculateManager.IsNumberDoubleType(firstStringNumber))
                 uiManager.ShowErrorMessage();
@@ -42,6 +47,23 @@ namespace ConsoleCalculator
                     uiManager.ShowErrorMessage();
 
                 uiManager.ShowResult(calculateManager, firstStringNumber, secondStringNumber, operatorSymbol, result);
+
+            }
+        }
+
+        //콘솔 키값 설정
+        static private void SetCurrentIndexKey(int currentIndex)
+        {
+            while (true)
+            {
+                var keyInfo = Console.ReadKey();
+                if (keyInfo.Key == ConsoleKey.Escape)
+                    break;
+                if (keyInfo.Key == ConsoleKey.UpArrow)
+                    currentIndex--;
+                if (keyInfo.Key == ConsoleKey.DownArrow)
+                    currentIndex++;
+                UIManager.ShowMemoryList(currentIndex);
             }
         }
     }

--- a/ConsoleCalculator/ConsoleCalculator/UIManager.cs
+++ b/ConsoleCalculator/ConsoleCalculator/UIManager.cs
@@ -51,5 +51,37 @@ namespace ConsoleCalculator
             Console.WriteLine("잘못 입력되었습니다.");
             Environment.Exit(0);
         }
+
+        //0 : MS 메모리 저장, 1 :M+ 메모리 더하기, 2 : M- 메모리 빼기, 3:MC : 메모리 지우기 4 : MR 메모리 불려오기
+        static public void ShowMemoryList(int currentIndex)
+        {
+            Console.Clear();
+            for (int i = 0; i < 5; i++)
+            {
+                Console.ForegroundColor = i == currentIndex ? ConsoleColor.Blue : ConsoleColor.Green;
+                Console.WriteLine("List : " + i);
+            }
+
+            switch (currentIndex)
+            {
+                case 0:
+                    Console.WriteLine("메모리 저장");
+                    break;
+                case 1:
+                    Console.WriteLine("메모리 더하기");
+                    break;
+                case 2:
+                    Console.WriteLine("메모리 빼기");
+                    break;
+                case 3:
+                    Console.WriteLine("메모리 지우기");
+                    break;
+                case 4:
+                    Console.WriteLine("메모리 불려오기");
+                    break;
+                default:
+                    break;
+            }
+        }
     }
 }

--- a/ConsoleCalculator/TestProject1/TestProject1.csproj
+++ b/ConsoleCalculator/TestProject1/TestProject1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
### 추가 사항
콘솔 키값 설정 기능
.net 7.0으로 변경 (비주얼 2022년으로 변경되면서 .net5.0 에러)

### 문제 발생
콘솔 키에 따른 이슈 발생
-> 종료 키 누른 후에 첫번째 문자 1개가 빠진 상태로 문자열 출력되는 현상 발생함
이후에 출력하는 문자에는 발생하지 않음.

참조)
https://stackoverflow.com/questions/16313042/console-readline-skips-the-first-input-character/16313759#16313759
https://social.msdn.microsoft.com/Forums/en-US/5d574123-14ea-44c6-bbe3-314347a05d2c/missing-character-from-consolereadline?forum=csharpgeneral

#### 해결책 고안
우선 출력할 글자에 @를 붙임... 
해결 방안 모색중...